### PR TITLE
Sea level CMIP6 data

### DIFF
--- a/climatedata_api/charts.py
+++ b/climatedata_api/charts.py
@@ -199,7 +199,7 @@ def generate_slr_charts(lati, loni):
         return "Bad request", 400
 
     if dataset_name == "CMIP5":
-        slr_path = app.config['NETCDF_SLR_PATH']
+        slr_path = app.config['NETCDF_SLR_CMIP5_PATH']
         low_p, high_p = "p05", "p95"
     else:
         slr_path = app.config['NETCDF_SLR_CMIP6_PATH']

--- a/climatedata_api/charts.py
+++ b/climatedata_api/charts.py
@@ -223,9 +223,10 @@ def generate_slr_charts(lati, loni):
         chart_series['rcp85_enhanced'] = [[dataset_enhanced['time'].item() / 10 ** 6,
                                            round(enhanced_location_slice['enhanced_p50'].item(), 0)]]
     else:  # CMIP6
-        for scenario in ['ssp585_slr_p83_low_conf', 'ssp585_slr_p98_high_end', 'uplift']:
-            chart_series[scenario] = convert_time_series_dataset_to_list(
-                location_slice[scenario], decimals=0)
+        for k,v in {"ssp585lowConf": "ssp585lowConf_slr_p83",
+                    "ssp585highEnd": "ssp585highEnd_slr_p98",
+                    "uplift": "uplift"}.items():
+            chart_series[k] = convert_time_series_dataset_to_list(location_slice[v], decimals=0)
 
     return chart_series
 

--- a/climatedata_api/charts.py
+++ b/climatedata_api/charts.py
@@ -209,7 +209,7 @@ def generate_slr_charts(lati, loni):
 
     chart_series = {}
 
-    for scenario in app.config['SCENARIOS']['CMIP5']:
+    for scenario in app.config['SCENARIOS'][dataset_name]:
         chart_series[scenario + '_median'] = convert_time_series_dataset_to_list(
             location_slice[f'{scenario}_slr_p50'], decimals=0)
         chart_series[scenario + '_range'] = convert_time_series_dataset_to_list(
@@ -223,9 +223,9 @@ def generate_slr_charts(lati, loni):
         chart_series['rcp85_enhanced'] = [[dataset_enhanced['time'].item() / 10 ** 6,
                                            round(enhanced_location_slice['enhanced_p50'].item(), 0)]]
     else:  # CMIP6
-        for scenario in ['ssp585_p83_low_conf', 'ssp585_p98_high_end', 'uplift']:
-            chart_series[scenario] = [[location_slice['time'].item() / 10 ** 6,
-                                       round(location_slice[scenario].item(), 0)]]
+        for scenario in ['ssp585_slr_p83_low_conf', 'ssp585_slr_p98_high_end', 'uplift']:
+            chart_series[scenario] = convert_time_series_dataset_to_list(
+                location_slice[scenario], decimals=0)
 
     return chart_series
 

--- a/climatedata_api/download.py
+++ b/climatedata_api/download.py
@@ -281,7 +281,7 @@ def download():
         if dataset_name not in ['CMIP5', 'CMIP6']:
             return (f"Bad request: Invalid dataset `{dataset_name}` for slr."
                     " Only `CMIP5` and `CMIP6` are available for slr."), 400
-        slr_path = app.config['NETCDF_SLR_PATH'] if dataset_name == "CMIP5" else app.config['NETCDF_SLR_CMIP6_PATH']
+        slr_path = app.config['NETCDF_SLR_CMIP5_PATH'] if dataset_name == "CMIP5" else app.config['NETCDF_SLR_CMIP6_PATH']
         datasets = [open_dataset_by_path(slr_path.format(root=app.config['DATASETS_ROOT']))]
     elif var in app.config['SPEI_VARIABLES']:
         datasets = [open_dataset_by_path(

--- a/climatedata_api/download.py
+++ b/climatedata_api/download.py
@@ -278,7 +278,11 @@ def download():
     scenarios = app.config['SCENARIOS'][dataset_name]
     limit = None
     if var == 'slr':
-        datasets = [open_dataset_by_path(app.config['NETCDF_SLR_PATH'].format(root=app.config['DATASETS_ROOT']))]
+        if dataset_name not in ['CMIP5', 'CMIP6']:
+            return (f"Bad request: Invalid dataset `{dataset_name}` for slr."
+                    " Only `CMIP5` and `CMIP6` are available for slr."), 400
+        slr_path = app.config['NETCDF_SLR_PATH'] if dataset_name == "CMIP5" else app.config['NETCDF_SLR_CMIP6_PATH']
+        datasets = [open_dataset_by_path(slr_path.format(root=app.config['DATASETS_ROOT']))]
     elif var in app.config['SPEI_VARIABLES']:
         datasets = [open_dataset_by_path(
             app.config['NETCDF_SPEI_FILENAME_FORMATS'].format(root=app.config['DATASETS_ROOT'], var=var))]

--- a/climatedata_api/map.py
+++ b/climatedata_api/map.py
@@ -138,11 +138,11 @@ def get_slr_gridded_values(lat, lon):
         enhanced_location_slice = dataset_enhanced.sel(lon=loni, lat=lati, method='nearest')
 
         slr_values = _convert_delta30_values_to_dict(
-            location_slice, 'slr', "", 0, 'CMIP5', percentiles=['p05', 'p50', 'p95'])
+            location_slice, 'slr', '', 0, 'CMIP5', percentiles=['p05', 'p50', 'p95'])
         slr_values['rcp85plus65'] = {'p50': round(enhanced_location_slice['enhanced_p50'].item(), 0)}
     else:  # CMIP6
         slr_values = _convert_delta30_values_to_dict(
-            location_slice, 'slr', "", 0, 'CMIP6', percentiles=['p17', 'p50', 'p83'])
+            location_slice, 'slr', '', 0, 'CMIP6', percentiles=['p17', 'p50', 'p83'])
         slr_values['ssp585lowConf'] = {'p83': round(location_slice['ssp585lowConf_slr_p83'].item(), 0)}
         slr_values['ssp585highEnd'] = {'p98': round(location_slice['ssp585highEnd_slr_p98'].item(), 0)}
         slr_values['uplift'] = {'uplift': round(location_slice['uplift'].item(), 0)}

--- a/climatedata_api/map.py
+++ b/climatedata_api/map.py
@@ -127,7 +127,7 @@ def get_slr_gridded_values(lat, lon):
     except (ValueError, BadRequestKeyError, KeyError):
         return "Bad request", 400
 
-    slr_path = app.config['NETCDF_SLR_PATH'] if dataset_name == "CMIP5" else app.config['NETCDF_SLR_CMIP6_PATH']
+    slr_path = app.config['NETCDF_SLR_CMIP5_PATH'] if dataset_name == "CMIP5" else app.config['NETCDF_SLR_CMIP6_PATH']
 
     dataset = open_dataset_by_path(slr_path.format(root=app.config['DATASETS_ROOT']))
     location_slice = dataset.sel(lon=loni, lat=lati, method='nearest').sel(time=f"{period}-01-01")

--- a/climatedata_api/map.py
+++ b/climatedata_api/map.py
@@ -143,8 +143,8 @@ def get_slr_gridded_values(lat, lon):
     else:  # CMIP6
         slr_values = _convert_delta30_values_to_dict(
             location_slice, 'slr', "", 0, 'CMIP6', percentiles=['p17', 'p50', 'p83'])
-        slr_values['ssp585_p83_low_conf'] = {'p83': round(location_slice['ssp585_slr_p83_low_conf'].item(), 0)}
-        slr_values['ssp585_p98_high_end'] = {'p98': round(location_slice['ssp585_slr_p98_high_end'].item(), 0)}
+        slr_values['ssp585lowConf'] = {'p83': round(location_slice['ssp585lowConf_slr_p83'].item(), 0)}
+        slr_values['ssp585highEnd'] = {'p98': round(location_slice['ssp585highEnd_slr_p98'].item(), 0)}
         slr_values['uplift'] = {'uplift': round(location_slice['uplift'].item(), 0)}
 
     return slr_values

--- a/climatedata_api/map.py
+++ b/climatedata_api/map.py
@@ -113,6 +113,7 @@ def get_slr_gridded_values(lat, lon):
     """
     Returns all values from sea-level change dataset for a requested location
     ex: curl http://localhost:5000/get-slr-gridded-values/61.04/-61.11?period=2050
+    ex: curl http://localhost:5000/get-slr-gridded-values/61.04/-61.11?period=2050&dataset_name=CMIP6
     :param lat: latitude (float as string)
     :param lon: longitude (float as string)
     """
@@ -120,19 +121,32 @@ def get_slr_gridded_values(lat, lon):
         lati = float(lat)
         loni = float(lon)
         period = int(request.args['period'])
+        dataset_name = request.args.get('dataset_name', 'CMIP5').upper()
+        if dataset_name not in ['CMIP5', 'CMIP6']:
+            raise KeyError("Invalid dataset requested")
     except (ValueError, BadRequestKeyError, KeyError):
         return "Bad request", 400
 
-    dataset = open_dataset_by_path(app.config['NETCDF_SLR_PATH'].format(root=app.config['DATASETS_ROOT']))
+    slr_path = app.config['NETCDF_SLR_PATH'] if dataset_name == "CMIP5" else app.config['NETCDF_SLR_CMIP6_PATH']
+
+    dataset = open_dataset_by_path(slr_path.format(root=app.config['DATASETS_ROOT']))
     location_slice = dataset.sel(lon=loni, lat=lati, method='nearest').sel(time=f"{period}-01-01")
 
-    dataset_enhanced = open_dataset_by_path(
-        app.config['NETCDF_SLR_ENHANCED_PATH'].format(root=app.config['DATASETS_ROOT']))
-    enhanced_location_slice = dataset_enhanced.sel(lon=loni, lat=lati, method='nearest')
+    if dataset_name == "CMIP5":
+        dataset_enhanced = open_dataset_by_path(
+            app.config['NETCDF_SLR_ENHANCED_PATH'].format(root=app.config['DATASETS_ROOT']))
+        enhanced_location_slice = dataset_enhanced.sel(lon=loni, lat=lati, method='nearest')
 
-    slr_values = _convert_delta30_values_to_dict(
-        location_slice, 'slr', "", 0, 'CMIP5', percentiles=['p05', 'p50', 'p95'])
-    slr_values['rcp85plus65'] = {'p50': round(enhanced_location_slice['enhanced_p50'].item(), 0)}
+        slr_values = _convert_delta30_values_to_dict(
+            location_slice, 'slr', "", 0, 'CMIP5', percentiles=['p05', 'p50', 'p95'])
+        slr_values['rcp85plus65'] = {'p50': round(enhanced_location_slice['enhanced_p50'].item(), 0)}
+    else:  # CMIP6
+        slr_values = _convert_delta30_values_to_dict(
+            location_slice, 'slr', "", 0, 'CMIP6', percentiles=['p17', 'p50', 'p83'])
+        slr_values['ssp585_p83_low_conf'] = {'p83': round(location_slice['ssp585_slr_p83_low_conf'].item(), 0)}
+        slr_values['ssp585_p98_high_end'] = {'p98': round(location_slice['ssp585_slr_p98_high_end'].item(), 0)}
+        slr_values['uplift'] = {'uplift': round(location_slice['uplift'].item(), 0)}
+
     return slr_values
 
 

--- a/default_settings.py
+++ b/default_settings.py
@@ -51,7 +51,7 @@ GRIDS = {'canadagrid': 'shapefiles/canadagrid/canadagrid.shp',
 NETCDF_SPEI_FILENAME_FORMATS = "{root}/SPEI/{var}/SPEI_ensemble_percentiles_allrcps_MON_1900_2100_{var}.nc"
 NETCDF_SPEI_OBSERVED_FILENAME_FORMATS = "{root}/SPEI/{var}/CCRC_CANGRD_MON_1900_2014_spei_bc_ref_period_195001_200512_timev_{var}.nc"
 
-NETCDF_SLR_PATH = "{root}/sealevel/Decadal_CMIP5_ensemble-percentiles_allrcps_2006-2100_slr_YS.nc"
+NETCDF_SLR_CMIP5_PATH = "{root}/sealevel/Decadal_CMIP5_ensemble-percentiles_allrcps_2006-2100_slr_YS.nc"
 NETCDF_SLR_ENHANCED_PATH = "{root}/sealevel/Decadal_0.1degree_CMIP5_ensemble-percentiles_enhancedscenario_2100_slc_YS_geoserver.nc"
 NETCDF_SLR_CMIP6_PATH = "{root}/sealevel/Decadal_CMIP6_ensemble-percentiles_allssps_2020-2150_slr_YS.nc"
 

--- a/default_settings.py
+++ b/default_settings.py
@@ -53,6 +53,7 @@ NETCDF_SPEI_OBSERVED_FILENAME_FORMATS = "{root}/SPEI/{var}/CCRC_CANGRD_MON_1900_
 
 NETCDF_SLR_PATH = "{root}/sealevel/Decadal_CMIP5_ensemble-percentiles_allrcps_2006-2100_slr_YS.nc"
 NETCDF_SLR_ENHANCED_PATH = "{root}/sealevel/Decadal_0.1degree_CMIP5_ensemble-percentiles_enhancedscenario_2100_slc_YS_geoserver.nc"
+NETCDF_SLR_CMIP6_PATH = "{root}/sealevel/Decadal_CMIP6_ensemble-percentiles_allssps_2020-2150_slr_YS.nc"
 
 SCENARIOS = {
     'CMIP5': ['rcp26', 'rcp45', 'rcp85'],


### PR DESCRIPTION
Updating the API to support new CMIP6 sea level data.
Updated `/download`, `/generate-charts` and `get-slr-gridded-values` endpoints.

Tested with :
`GET http://127.0.0.1:5000/get-slr-gridded-values/61.212233199834/-69.95044720943544?period=2150&dataset_name=CMIP6`

`GET http://127.0.0.1:5000/generate-charts/60.76466431637464/-68.14855476961694/slr/ann?dataset_name=CMIP6`

`curl  -s http://localhost:5000/download -H "Content-Type: application/json" -X POST -d '{ "var" : "slr",
          "month" : "ann",
          "format" : "json",
          "points": [[55.42513582045793, -80.15217520306425]], "dataset_name": "CMIP6"
        }'`