### PR TITLE
Vertical Allowance data

### DIFF
--- a/climatedata_api/app.py
+++ b/climatedata_api/app.py
@@ -9,7 +9,8 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from climatedata_api.charts import generate_charts, generate_regional_charts
 from climatedata_api.download import (download, download_30y, download_ahccd,
                                       download_regional_30y)
-from climatedata_api.map import (get_choro_values,
+from climatedata_api.map import (get_allowance_gridded_values,
+                                 get_choro_values,
                                  get_delta_30y_gridded_values,
                                  get_delta_30y_regional_values,
                                  get_slr_gridded_values,
@@ -44,6 +45,7 @@ app.add_url_rule('/get-choro-values/<partition>/<var>/<scenario>/<month>/', view
 app.add_url_rule('/get-choro-values/<partition>/<var>/<scenario>', view_func=get_choro_values)
 app.add_url_rule('/get-delta-30y-gridded-values/<lat>/<lon>/<var>/<month>', view_func=get_delta_30y_gridded_values)
 app.add_url_rule('/get-slr-gridded-values/<lat>/<lon>', view_func=get_slr_gridded_values)
+app.add_url_rule('/get-allowance-gridded-values/<lat>/<lon>', view_func=get_allowance_gridded_values)
 app.add_url_rule('/get-delta-30y-regional-values/<partition>/<index>/<var>/<month>',
                  view_func=get_delta_30y_regional_values)
 app.add_url_rule('/get-gids/<compressed_points>', view_func=get_id_list_from_points)

--- a/climatedata_api/charts.py
+++ b/climatedata_api/charts.py
@@ -111,6 +111,11 @@ def generate_charts(var, lat, lon, month='ann'):
     if var == 'slr':
         return generate_slr_charts(lati, loni)
 
+    if var == 'allowance':
+        if dataset_name != 'CMIP6':
+            return f"Bad request : `allowance` variable only uses the CMIP6 dataset, and has no {dataset_name} data available.\n", 400
+        return generate_allowance_charts(lati, loni)
+
     try:
         observations_dataset = open_dataset(app.config['OBSERVATIONS_DATASET'][dataset_name],
                                             'allyears', var, msys, monthpath)
@@ -207,6 +212,22 @@ def generate_slr_charts(lati, loni):
                       location_slice[f'{scenario}_slr_p95']]), decimals=0)
     chart_series['rcp85_enhanced'] = [[dataset_enhanced['time'].item() / 10 ** 6,
                                        round(enhanced_location_slice['enhanced_p50'].item(), 0)]]
+
+    return chart_series
+
+
+def generate_allowance_charts(lati, loni):
+    """
+        Copied from generate_slr_charts: no historical, no observations, single file
+        ex: curl http://localhost:5000/generate-charts/58.031372421776396/-61.12792968750001/allowance/ann?dataset_name=CMIP6
+    """
+    dataset = open_dataset_by_path(app.config['NETCDF_ALLOWANCE_PATH'].format(root=app.config['DATASETS_ROOT']))
+    location_slice = dataset.sel(lon=loni, lat=lati, method='nearest').drop(['lat', 'lon']).dropna('time')
+
+    chart_series = {}
+    for scenario in app.config['SCENARIOS']['CMIP6']:
+        chart_series[scenario] = convert_time_series_dataset_to_list(
+            location_slice[f'{scenario}_allowance_p50'], decimals=0)
 
     return chart_series
 

--- a/climatedata_api/charts.py
+++ b/climatedata_api/charts.py
@@ -193,7 +193,7 @@ def generate_spei_charts(var, lati, loni, month, decimals):
 def generate_slr_charts(lati, loni):
     """
         Copied from generate_spei_charts: no historical, no observations, single file
-        ex: curl http://localhost:5000/generate-charts/58.031372421776396/-61.12792968750001/slr/ann
+        ex: curl http://localhost:5000/generate-charts/58.031372421776396/-61.12792968750001/slr/ann?dataset_name=CMIP6
     """
     dataset = open_dataset_by_path(app.config['NETCDF_SLR_PATH'].format(root=app.config['DATASETS_ROOT']))
     location_slice = dataset.sel(lon=loni, lat=lati, method='nearest').drop(['lat', 'lon']).dropna('time')

--- a/climatedata_api/download.py
+++ b/climatedata_api/download.py
@@ -279,6 +279,10 @@ def download():
     limit = None
     if var == 'slr':
         datasets = [open_dataset_by_path(app.config['NETCDF_SLR_PATH'].format(root=app.config['DATASETS_ROOT']))]
+    elif var == 'allowance':
+        if dataset_name != 'CMIP6':
+            return f"Bad request : `allowance` variable only uses the CMIP6 dataset, and has no {dataset_name} data available.\n", 400
+        datasets = [open_dataset_by_path(app.config['NETCDF_ALLOWANCE_PATH'].format(root=app.config['DATASETS_ROOT']))]
     elif var in app.config['SPEI_VARIABLES']:
         datasets = [open_dataset_by_path(
             app.config['NETCDF_SPEI_FILENAME_FORMATS'].format(root=app.config['DATASETS_ROOT'], var=var))]

--- a/climatedata_api/map.py
+++ b/climatedata_api/map.py
@@ -156,10 +156,10 @@ def get_allowance_gridded_values(lat, lon):
     dataset = open_dataset_by_path(app.config['NETCDF_ALLOWANCE_PATH'].format(root=app.config['DATASETS_ROOT']))
     location_slice = dataset.sel(lon=loni, lat=lati, method='nearest').sel(time=f"{period}-01-01")
 
-    slr_values = _convert_delta30_values_to_dict(
+    allowance_values = _convert_delta30_values_to_dict(
         location_slice, 'allowance', "", 0, dataset_name, percentiles=['p50'])
 
-    return slr_values
+    return allowance_values
 
 
 def get_delta_30y_regional_values(partition, index, var, month):

--- a/climatedata_api/map.py
+++ b/climatedata_api/map.py
@@ -136,6 +136,32 @@ def get_slr_gridded_values(lat, lon):
     return slr_values
 
 
+def get_allowance_gridded_values(lat, lon):
+    """
+    Returns all values from vertical allowance dataset for a requested location
+    ex: curl http://localhost:5000/get-allowance-gridded-values/61.04/-61.11?period=2050&dataset_name=CMIP6
+    :param lat: latitude (float as string)
+    :param lon: longitude (float as string)
+    """
+    try:
+        lati = float(lat)
+        loni = float(lon)
+        period = int(request.args['period'])
+        dataset_name = request.args.get('dataset_name', 'CMIP6').upper()
+        if dataset_name not in ['CMIP6']:
+            raise KeyError("Invalid dataset requested")
+    except (ValueError, BadRequestKeyError, KeyError):
+        return "Bad request", 400
+
+    dataset = open_dataset_by_path(app.config['NETCDF_ALLOWANCE_PATH'].format(root=app.config['DATASETS_ROOT']))
+    location_slice = dataset.sel(lon=loni, lat=lati, method='nearest').sel(time=f"{period}-01-01")
+
+    slr_values = _convert_delta30_values_to_dict(
+        location_slice, 'allowance', "", 0, dataset_name, percentiles=['p50'])
+
+    return slr_values
+
+
 def get_delta_30y_regional_values(partition, index, var, month):
     """
     Fetch specific data within the delta30y partitionned dataset (health/census/...)

--- a/default_settings.py
+++ b/default_settings.py
@@ -54,6 +54,8 @@ NETCDF_SPEI_OBSERVED_FILENAME_FORMATS = "{root}/SPEI/{var}/CCRC_CANGRD_MON_1900_
 NETCDF_SLR_PATH = "{root}/sealevel/Decadal_CMIP5_ensemble-percentiles_allrcps_2006-2100_slr_YS.nc"
 NETCDF_SLR_ENHANCED_PATH = "{root}/sealevel/Decadal_0.1degree_CMIP5_ensemble-percentiles_enhancedscenario_2100_slc_YS_geoserver.nc"
 
+NETCDF_ALLOWANCE_PATH =  "{root}/allowance/Decadal_CMIP6_median_allssps_2020-2150_allowance_YS.nc"
+
 SCENARIOS = {
     'CMIP5': ['rcp26', 'rcp45', 'rcp85'],
     'CMIP6': ['ssp126', 'ssp245', 'ssp370', 'ssp585'],
@@ -71,7 +73,8 @@ SPEI_DATE_LIMIT = '1950-01-01'
 KELVIN_TO_C = -273.15
 DOWNLOAD_POINTS_LIMIT = 1000
 
-VARIABLES = ['cdd',
+VARIABLES = ['allowance',
+             'cdd',
              'cddcold_18',
              'dlyfrzthw_tx0_tn-1',
              'frost_days',

--- a/tests/api/test_api_charts.py
+++ b/tests/api/test_api_charts.py
@@ -28,6 +28,11 @@ from tests.configs import TEST_HOST_URL
             id="generate_slr_charts",
         ),
         pytest.param(
+            f"{TEST_HOST_URL}/generate-charts/58.031372421776396/-61.12792968750001/allowance/ann?dataset_name=CMIP6",
+            200,
+            id="generate_allowance_charts",
+        ),
+        pytest.param(
             f"{TEST_HOST_URL}/generate-regional-charts/census/4510/tx_max/ann",
             200,
             id="generate_regional_charts"

--- a/tests/api/test_api_download.py
+++ b/tests/api/test_api_download.py
@@ -202,6 +202,23 @@ def test_api_download_get(url: str, status_code: int):
             f"{TEST_HOST_URL}/download",
             200,
             {
+                "var": "allowance",
+                "month": "ann",
+                "format": "csv",
+                "dataset_name": "CMIP6",
+                "points": [
+                    [55.615479404227266, -80.75205994818893],
+                    [55.615479404227266, -80.57633593798099],
+                    [55.54715240897225, -80.63124969117096],
+                    [55.54093496609795, -80.70812894563693],
+                ]
+            },
+            id="download_dataset_allowance_csv",
+        ),
+        pytest.param(
+            f"{TEST_HOST_URL}/download",
+            200,
+            {
                 "var": "spei_3m",
                 "month": "dec",
                 "format": "csv",

--- a/tests/api/test_api_map.py
+++ b/tests/api/test_api_map.py
@@ -38,6 +38,11 @@ from tests.configs import TEST_HOST_URL
             id="get_slr_gridded_values"
         ),
         pytest.param(
+            f"{TEST_HOST_URL}/get-allowance-gridded-values/61.04/-61.11?period=2050",
+            200,
+            id="get_allowance_gridded_values"
+        ),
+        pytest.param(
             f"{TEST_HOST_URL}/get-delta-30y-regional-values/census/4510/tx_max/ann?period=1951",
             200,
             id="get_delta_30y_regional_values",


### PR DESCRIPTION
Updating the API to support new CMIP6 vertical allowance data.
Updated `/download`, `/generate-charts` and `/get-allowance-gridded-values` endpoints.

Tested with :
```
GET http://127.0.0.1:5000/get-allowance-gridded-values/61.212233199834/-69.95044720943544?period=2150&dataset_name=CMIP6

GET http://127.0.0.1:5000/generate-charts/60.76466431637464/-68.14855476961694/allowance/ann?dataset_name=CMIP6

curl  -s http://localhost:5000/download -H "Content-Type: application/json" -X POST -d '{ "var" : "allowance", "month" : "ann", "format" : "json", "points": [[55.42513582045793, -80.15217520306425]], "dataset_name": "CMIP6" }'
```