### PR TITLE
CLIM-1121: Fix: /get-s2d-release-date doesn't return in JSON format

### DIFF
--- a/climatedata_api/download.py
+++ b/climatedata_api/download.py
@@ -19,9 +19,16 @@ from flask import current_app as app
 from flask import request, send_file
 from werkzeug.exceptions import BadRequestKeyError
 
-from climatedata_api.map import get_s2d_release_date
-from climatedata_api.utils import format_metadata, make_zip, open_dataset, open_dataset_by_path, \
-    load_s2d_datasets_by_periods, get_subset_by_bbox, get_subset_by_points
+from climatedata_api.utils import (
+    format_metadata,
+    make_zip,
+    open_dataset,
+    open_dataset_by_path,
+    load_s2d_datasets_by_periods,
+    get_subset_by_bbox,
+    get_subset_by_points,
+    retrieve_s2d_release_date,
+)
 from default_settings import (
     DOWNLOAD_CSV_FORMAT,
     DOWNLOAD_JSON_FORMAT,
@@ -748,7 +755,7 @@ def download_s2d():
     except (BadRequestKeyError, KeyError, TypeError):
         return "Bad request", 400
 
-    release_date = datetime.strptime(get_s2d_release_date(var, freq), "%Y-%m-%d")
+    release_date = datetime.strptime(retrieve_s2d_release_date(var, freq), "%Y-%m-%d")
 
     try:
         forecast_slice, climatology_slice, skill_slice = load_s2d_datasets_by_periods(var, freq, period_dates, release_date)

--- a/climatedata_api/utils.py
+++ b/climatedata_api/utils.py
@@ -320,8 +320,7 @@ def get_subset_by_points(dataset: xr.Dataset, points: list[Tuple[float, float]])
 
 def retrieve_s2d_release_date(var, freq):
     """
-    Return the release date of the forecast data associated with a given variable and frequency
-    curl 'http://localhost:5000/get-s2d-release-date/air_temp/seasonal'
+    Return the release date of the forecast data associated with a given variable and frequency.
 
     The returned string is in the YYYY-MM-DD format.
     The input data should normally only use the first day of months, so the returned day is always "01".

--- a/climatedata_api/utils.py
+++ b/climatedata_api/utils.py
@@ -316,3 +316,24 @@ def get_subset_by_points(dataset: xr.Dataset, points: list[Tuple[float, float]])
 
     filtered_ds = subset.where(mask)
     return filtered_ds
+
+
+def retrieve_s2d_release_date(var, freq):
+    """
+    Return the release date of the forecast data associated with a given variable and frequency
+    curl 'http://localhost:5000/get-s2d-release-date/air_temp/seasonal'
+
+    The returned string is in the YYYY-MM-DD format.
+    The input data should normally only use the first day of months, so the returned day is always "01".
+    """
+    if (var not in app.config['S2D_VARIABLES']) or (freq not in app.config['S2D_FREQUENCIES']):
+        raise ValueError(f"Invalid variable or frequency: {var} {freq}")
+
+    dataset = open_dataset_by_path(app.config['NETCDF_S2D_FORECAST_FILENAME_FORMATS'].format(
+        root=app.config['DATASETS_ROOT'],
+        var=var,
+        freq=freq
+    ))
+
+    latest_datetime = dataset['time'].min().values
+    return str(latest_datetime.astype('datetime64[D]'))

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -32,7 +32,7 @@ class TestDownloadS2D:
     @pytest.mark.parametrize("file_format", [DOWNLOAD_NETCDF_FORMAT, DOWNLOAD_CSV_FORMAT, DOWNLOAD_JSON_FORMAT])
     @pytest.mark.parametrize("subset_type", ["points", "bbox"])
     @pytest.mark.parametrize("forecast_type", [S2D_FORECAST_TYPE_EXPECTED, S2D_FORECAST_TYPE_UNUSUAL])
-    @patch("climatedata_api.download.get_s2d_release_date", return_value="2025-01-01")
+    @patch("climatedata_api.download.retrieve_s2d_release_date", return_value="2025-01-01")
     @patch("climatedata_api.utils.open_dataset_by_path")
     def test_valid_payload(self, mock_open_dataset, mock_release, test_app, client, file_format, subset_type, forecast_type):
         """


### PR DESCRIPTION
Issue: the `/get-s2d-release-date` endpoint returns the date, but not as a _JSON_ string (between double quotes).

This PR changes the return value of the endpoint to be a valid JSON response.

CLIM-1121