### PR TITLE
CLIM-1454: update the raster endpoint for new screenshots layout

### DIFF
--- a/climatedata_api/app.py
+++ b/climatedata_api/app.py
@@ -20,7 +20,7 @@ from climatedata_api.map import (get_allowance_gridded_values,
                                  get_s2d_gridded_values)
 from climatedata_api.siteinfo import (get_location_values,
                                       get_location_values_allyears)
-from climatedata_api.raster import get_raster_route
+from climatedata_api.raster import post_raster_route
 from climatedata_api.utils import generate_kdtrees
 
 pd.set_option('display.max_rows', 10000)
@@ -67,7 +67,7 @@ app.add_url_rule('/get_location_values_allyears.php', view_func=get_location_val
 app.add_url_rule('/get-location-values/<lat>/<lon>', view_func=get_location_values)
 
 # raster routes
-app.add_url_rule('/raster', view_func=get_raster_route)
+app.add_url_rule('/raster', view_func=post_raster_route, methods=['GET', 'POST'])
 
 # geomet routes
 app.add_url_rule('/get-geomet-collection-items-links/<collectionId>', view_func=get_geomet_collection_download_links)

--- a/climatedata_api/raster.py
+++ b/climatedata_api/raster.py
@@ -1,5 +1,6 @@
 import base64
 import functools
+import json
 import os
 
 from selenium import webdriver
@@ -34,7 +35,7 @@ def get_selenium_driver():
     return webdriver.Chrome(service=chrome_service, options=chrome_options)
 
 
-def get_raster(url, output_img_path):
+def get_raster(url, output_img_path, location_popup_html=None, marker_lat_lon=None):
     """
         Raster the "explore location" chart.
         Notes: * URL is encoded using tools/encoder.html
@@ -48,6 +49,8 @@ def get_raster(url, output_img_path):
 
         :param url: URL to raster
         :param output_img_path: output path of the raster
+        :param location_popup_html: optional array of HTML strings to pass to JavaScript
+        :param marker_lat_lon: optional [lat, lon] pair to pass to JavaScript
     """
     driver = get_selenium_driver()
     driver.get(url)
@@ -55,7 +58,13 @@ def get_raster(url, output_img_path):
     try:
         WebDriverWait(driver, 10).until(EC.visibility_of_element_located((By.TAG_NAME, "body")))
         time.sleep(1)
-        driver.execute_script("$.fn.prepare_raster();")
+
+        # Call prepare_raster with optional parameters
+        if location_popup_html is not None and marker_lat_lon is not None:
+            script = f"$.fn.prepare_raster({json.dumps(location_popup_html)}, {json.dumps(marker_lat_lon)});"
+            driver.execute_script(script)
+        else:
+            driver.execute_script("$.fn.prepare_raster();")
 
         # Make sure the raster is ready before taking a screenshot.
         WebDriverWait(driver, 10).until(EC.visibility_of_element_located((By.CLASS_NAME, "to-raster")))
@@ -98,11 +107,43 @@ def decode_and_validate_url(encoded_url):
     return url
 
 
-def get_raster_route():
+def post_raster_route():
     """
-        Validate encoded URL and perform raster if valid
+        Validate encoded URL and render a raster image if valid
+        Payload content that is passed to the Javascript to render the raster:
+        - locationPopupHtml: array of 1 or 2 strings containing the HTML content of a location popup displayed on the map
+        - markerLatLon : array of 2 floats containing the lat/lon coordinates of the marker displayed on the map
+
+        Example POST payload:
+        {
+            'locationPopupHtml' : ["<div>Test</div>", "<div>Test 2</div>"]',
+            'markerLatLon': [45.6323,-73.8124],
+        }
+
         :return: response containing the output image
     """
+    location_popup_html = None
+    marker_lat_lon = None
+
+    if request.method == 'POST':
+        args = request.get_json()
+
+        # Validate POST payload
+        if args:
+            location_popup_html_raw = args.get('locationPopupHtml')
+            if location_popup_html_raw is not None:
+                if isinstance(location_popup_html_raw, list) and 1 <= len(location_popup_html_raw) <= 2:
+                    if all(isinstance(item, str) for item in location_popup_html_raw):
+                        location_popup_html = location_popup_html_raw
+
+            marker_raw = args.get('markerLatLon')
+            if marker_raw is not None:
+                if isinstance(marker_raw, (list, tuple)) and len(marker_raw) == 2:
+                    try:
+                        marker_lat_lon = [float(marker_raw[0]), float(marker_raw[1])]
+                    except (ValueError, TypeError):
+                        pass
+
     encoded_url = request.args.get('url')
     url = decode_and_validate_url(encoded_url)
     parsed_url = urlparse(url)
@@ -115,7 +156,7 @@ def get_raster_route():
 
     output_img_path = "/tmp/" + str(uuid.uuid4()) + ".png"
 
-    get_raster(url, output_img_path)
+    get_raster(url, output_img_path, location_popup_html, marker_lat_lon)
 
     f = open(output_img_path, "rb")
     os.unlink(output_img_path)

--- a/tests/api/test_api_raster.py
+++ b/tests/api/test_api_raster.py
@@ -1,5 +1,8 @@
 import pytest
-from climatedata_api.raster import calculate_hash
+import json
+from unittest.mock import patch, MagicMock
+from climatedata_api.raster import calculate_hash, post_raster_route, get_raster
+from climatedata_api.app import app
 
 
 @pytest.mark.parametrize(
@@ -13,3 +16,161 @@ from climatedata_api.raster import calculate_hash
 )
 def test_calculate_hash(s, expected):
     assert calculate_hash(s) == expected
+
+
+class TestPostRasterFunction:
+    """Tests for the post_raster_route() function with parameter validation"""
+
+    @pytest.fixture
+    def app_context(self):
+        """Setup Flask app context for testing"""
+        with app.app_context():
+            yield app
+
+    def _setup_route_mocks(self, mock_get_raster, mock_decode):
+        """Configure common mock values used by post_raster_route tests."""
+        mock_decode.return_value = "https://climatedata.crim.ca/test"
+        mock_get_raster.return_value = None
+
+    def _invoke_post_raster_route(self, app_context, method, payload=None):
+        """Invoke post_raster_route with mocking."""
+        app_context.config['ALLOWED_DOMAINS'] = ['climatedata.crim.ca']
+        # Mock functions related to file handling
+        with patch('climatedata_api.raster.send_file'):
+            with patch('climatedata_api.raster.os.unlink'):
+                with patch('builtins.open'):
+                    with app_context.test_request_context(
+                        '/raster?url=test_encoded_url',
+                        method=method,
+                        json=payload,
+                    ):
+                        return post_raster_route()
+
+    @patch('climatedata_api.raster.decode_and_validate_url')
+    @patch('climatedata_api.raster.get_raster')
+    def test_post_raster_route_valid_payload(self, mock_get_raster, mock_decode, app_context):
+        """Tests post_raster_route with a valid POST payload"""
+
+        self._setup_route_mocks(mock_get_raster, mock_decode)
+
+        test_location_popup_html = ["<div>Test HTML</div>", "<div>Test 2 HTML</div>"]
+        test_marker = [45.5, -120.3]
+        self._invoke_post_raster_route(
+            app_context,
+            method='POST',
+            payload={
+                'locationPopupHtml': test_location_popup_html,
+                'markerLatLon': test_marker,
+            },
+        )
+
+        mock_get_raster.assert_called_once()
+        call_args = mock_get_raster.call_args
+        assert call_args[0][2] == test_location_popup_html  # location_popup_html argument
+        assert call_args[0][3] == test_marker  # marker_lat_lon argument
+
+    @patch('climatedata_api.raster.decode_and_validate_url')
+    @patch('climatedata_api.raster.get_raster')
+    def test_post_raster_route_with_invalid_location_popup_html(self, mock_get_raster, mock_decode, app_context):
+        """Tests if post_raster_route validates locationPopupHtml parameter"""
+
+        self._setup_route_mocks(mock_get_raster, mock_decode)
+        self._invoke_post_raster_route(
+            app_context,
+            method='POST',
+            payload={
+                'locationPopupHtml': ["<div>1</div>", "<div>2</div>", "<div>3</div>"],  # Invalid: 3 items
+                'markerLatLon': [45.5, -120.3],
+            },
+        )
+
+        call_args = mock_get_raster.call_args
+        assert call_args[0][2] is None  # location_popup_html is None (failed validation)
+        assert call_args[0][3] == [45.5, -120.3]  # marker_lat_lon argument
+
+    @patch('climatedata_api.raster.decode_and_validate_url')
+    @patch('climatedata_api.raster.get_raster')
+    def test_post_raster_route_with_invalid_marker(self, mock_get_raster, mock_decode, app_context):
+        """Tests if post_raster_route validates markerLatLon parameter"""
+
+        self._setup_route_mocks(mock_get_raster, mock_decode)
+        self._invoke_post_raster_route(
+            app_context,
+            method='POST',
+            payload={
+                'locationPopupHtml': ["<div>Test</div>"],
+                'markerLatLon': [45.5, -120.3, 100],  # Invalid: 3 values instead of 2
+            },
+        )
+
+        call_args = mock_get_raster.call_args
+        assert call_args[0][2] == ["<div>Test</div>"]  # location_popup_html argument
+        assert call_args[0][3] is None  # marker_lat_lon is None (failed validation)
+
+    @patch('climatedata_api.raster.decode_and_validate_url')
+    @patch('climatedata_api.raster.get_raster')
+    def test_post_raster_route_backward_compatibility_no_params(self, mock_get_raster, mock_decode, app_context):
+        """Test backward compatibility - GET request without new parameters"""
+
+        self._setup_route_mocks(mock_get_raster, mock_decode)
+        self._invoke_post_raster_route(app_context, method='GET')
+
+        # Verify get_raster was called with None values (no params provided)
+        call_args = mock_get_raster.call_args
+        assert call_args[0][2] is None  # location_popup_html argument
+        assert call_args[0][3] is None  # marker_lat_lon argument
+
+
+class TestGetRasterFunction:
+    """Tests for the get_raster() function to verify JavaScript execution"""
+
+    def _setup_mock_driver(self, mock_get_driver):
+        """Create and register a mock Selenium driver."""
+        mock_driver = MagicMock()
+        mock_driver.find_element.return_value = MagicMock()
+        mock_get_driver.return_value = mock_driver
+        return mock_driver
+
+    def _invoke_get_raster(self, *args):
+        """Invoke get_raster with common wait/sleep patching."""
+        with patch('climatedata_api.raster.WebDriverWait'):
+            with patch('climatedata_api.raster.time.sleep'):
+                get_raster(*args)
+
+    @patch('climatedata_api.raster.get_selenium_driver')
+    def test_get_raster_no_payload(self, mock_get_driver):
+        """Test that prepare_raster is called without params when none provided"""
+
+        mock_driver = self._setup_mock_driver(mock_get_driver)
+        self._invoke_get_raster("http://test.com", "/tmp/test.png")
+
+        # Verify execute_script was called with correct function
+        calls = mock_driver.execute_script.call_args_list
+        assert any("$.fn.prepare_raster();" in str(call) for call in calls)
+
+    @patch('climatedata_api.raster.get_selenium_driver')
+    def test_get_raster_with_payload(self, mock_get_driver):
+        """Test that prepare_raster is called WITH params when provided"""
+
+        mock_driver = self._setup_mock_driver(mock_get_driver)
+
+        location_popup_html = ["<div>Test</div>"]
+        marker = [45.5, -120.3]
+
+        self._invoke_get_raster("http://test.com", "/tmp/test.png", location_popup_html, marker)
+
+        calls = mock_driver.execute_script.call_args_list
+
+        # Find the call with parameters
+        param_call = None
+        for call in calls:
+            if call[0] and call[0][0] and "prepare_raster" in call[0][0]:
+                param_call = call[0][0]
+                break
+
+        assert param_call is not None, "prepare_raster call not found"
+
+        # Verify the JavaScript contains JSON-serialized parameters
+        assert json.dumps(location_popup_html) in param_call
+        assert json.dumps(marker) in param_call
+        assert "$.fn.prepare_raster(" in param_call


### PR DESCRIPTION
`/raster` endpoint is now a POST method, which supports a payload containing some elements that are required by the Javascript `prepare_raster()` method, for the new screenshots layout implemented for Maps screenshot download.

The payload contains HTML content for the location popup, and the lat/lon position of the black marker displayed on the map.

Note that for backward compatibility, the GET method is still supported. The raster method can still be called without the payload, to ensure a smoother migration to the new endpoint implementation.